### PR TITLE
Refine DocuMind AI workflows for direct /document usage

### DIFF
--- a/src/templates/ai-configs/claude.md
+++ b/src/templates/ai-configs/claude.md
@@ -1,102 +1,89 @@
 # Claude Configuration
 
-This repository uses **DocuMind** for intelligent documentation management with automatic dual-purpose generation.
+DocuMind manages documentation through the `/document` command family. Claude agents should follow the behaviors defined in [`src/core/commands.md`](../../core/commands.md) and the mirrored runtime reference at `.documind/core/commands.md` when installed locally.
 
-## Automatic Documentation Generation
+## Unified Workflow Pattern
+For every request that maps to a `/document` intent, follow this consistent structure:
+1. **Classify the intent** using the patterns below.
+2. **Execute the matching `/document …` command** with clear arguments.
+3. **Interpret the command response** (or available repository context) to craft the final explanation.
+4. **Provide the expected output summary** and any follow-up options.
+5. **Fallback**: If the `/document` command cannot be executed, gather the necessary repository context manually and draft the documentation yourself before summarizing the results.
 
-When users request documentation, DocuMind automatically generates BOTH human-readable and AI-optimized documentation in a single operation. This provides comprehensive documentation coverage without requiring users to understand the dual-purpose nature.
+## Command Playbook
+Each command entry lists natural language cues Claude should recognize, followed by the intent, required actions, and the output standard.
 
-### How It Works
+### `/document bootstrap`
+- **Natural language cues**: "Generate all project docs", "Bootstrap the documentation", "Create complete documentation".
+- **Intent**: Produce the end-to-end documentation set for the project.
+- **Expected LLM actions**:
+  1. Run `/document bootstrap` to trigger the comprehensive generation routine described in the command reference.
+  2. Review the resulting documentation structure, noting key directories and files.
+  3. If the command is unavailable, compile a manual overview covering project setup, architecture, integrations, and contributor guidance.
+- **Output expectations**:
+  - Summarize the new or updated files in `/docs/` and any AI-focused outputs.
+  - Highlight navigation or index updates.
+  - Offer next steps (e.g., expand or update commands) if gaps remain.
 
-1. **Detect DocuMind**: Check for `.documind/` installation
-2. **Execute Orchestrator**: Run AI orchestration script for comprehensive generation
-3. **Generate Both Types**: Create human docs in `/docs/` and AI docs in `/docs/ai/`
-4. **Present Results**: Show user the complete documentation generated
+### `/document expand [concept]`
+- **Natural language cues**: "Document the authentication system", "Explain how billing works", "Add docs for the queue processor".
+- **Intent**: Create or enrich documentation for a focused concept, component, or workflow.
+- **Expected LLM actions**:
+  1. Execute `/document expand <concept>` with a descriptive concept name.
+  2. Inspect the generated concept documentation to verify coverage of purpose, architecture, and examples.
+  3. If execution fails, manually draft the concept documentation using code insights and existing docs.
+- **Output expectations**:
+  - Present the concept summary, key flows, and related references.
+  - Note any new files added under `/docs/02-core-concepts/` or analogous locations.
+  - Suggest related concepts or follow-up updates if beneficial.
 
-## Documentation Commands
+### `/document update [section]`
+- **Natural language cues**: "Refresh the setup guide", "Update the API docs", "Fix outdated deployment steps".
+- **Intent**: Refresh an existing documentation section so that it reflects the current implementation.
+- **Expected LLM actions**:
+  1. Call `/document update <section>` targeting the relevant guide or area.
+  2. Compare prior guidance with new changes to confirm accuracy.
+  3. If automatic updates are unavailable, revise the section manually with the latest code or configuration details.
+- **Output expectations**:
+  - Describe the adjustments made, including files touched and issues resolved.
+  - Point out any remaining open questions or TODOs discovered during the update.
 
-When users request documentation using these commands, automatically execute the DocuMind AI orchestrator:
+### `/document analyze [integration]`
+- **Natural language cues**: "How do we use Stripe?", "Document the MongoDB integration", "Explain our AWS setup".
+- **Intent**: Produce integration-focused documentation that maps external services to in-repo usage.
+- **Expected LLM actions**:
+  1. Run `/document analyze <integration>` using the service name or integration focus.
+  2. Review the resulting integration guide for configuration, API usage, and failure modes.
+  3. If the command cannot run, investigate the codebase (e.g., environment files, service wrappers) and author the guide manually.
+- **Output expectations**:
+  - Summarize integration purpose, configuration steps, and key code references.
+  - List any credentials, environment variables, or monitoring tips highlighted by the analysis.
 
-- `/document bootstrap` - Generate complete project documentation (both human and AI)
-- `/document expand [concept]` - Create detailed documentation for concepts
-- `/document update [section]` - Refresh existing documentation sections
-- `/document analyze [integration]` - Document external service integrations
-- `/document index` - Rebuild documentation navigation and links
-- `/document search [query]` - Search existing documentation
+### `/document index`
+- **Natural language cues**: "Rebuild the navigation", "Fix the documentation index", "Refresh cross-references".
+- **Intent**: Regenerate documentation navigation, tables of contents, and cross-links.
+- **Expected LLM actions**:
+  1. Execute `/document index` to rebuild navigation assets per the command reference.
+  2. Confirm that indexes and linkages reflect the current file set.
+  3. When automated rebuilding is unavailable, manually audit navigation files and adjust links accordingly.
+- **Output expectations**:
+  - Report navigation files touched (e.g., sidebar configs, AI indices).
+  - Call out any broken links or inconsistencies that still require attention.
 
-## Natural Language Recognition
+### `/document search [query]`
+- **Natural language cues**: "Find docs about authentication", "Search for deployment steps", "Where is the API reference?".
+- **Intent**: Locate existing documentation relevant to a user query.
+- **Expected LLM actions**:
+  1. Invoke `/document search <query>` with the requested topic.
+  2. Review the returned matches and extract pertinent excerpts.
+  3. If searching is unsupported, inspect the `/docs/` tree manually (and optionally the codebase) to answer the query.
+- **Output expectations**:
+  - Provide a ranked list of relevant sections with short summaries and file paths.
+  - Identify gaps where new documentation might be needed.
 
-Recognize these patterns as documentation requests and execute the orchestrator:
+## Fallback and Support Guidance
+- When `/document` commands are unavailable, Claude must still fulfill the request by synthesizing documentation directly from repository context.
+- Clearly state when manual drafting was required and provide actionable suggestions for installing or updating DocuMind if appropriate.
+- Encourage users to consult `.documind/core/commands.md` for the definitive command semantics when working locally.
 
-- "Document this feature" → `/document expand [feature]`
-- "Update the installation guide" → `/document update installation`
-- "How do we use MongoDB?" → `/document analyze mongodb`
-- "Create API documentation" → `/document expand api`
-- "Generate project docs" → `/document bootstrap`
-- "Find documentation about authentication" → `/document search authentication`
-
-## Execution Instructions
-
-For ALL documentation commands, follow this workflow:
-
-### 1. Detection Phase
-```bash
-# Check if DocuMind is available
-node .documind/scripts/detect-documind.js ai-report
-```
-
-### 2. Execution Phase (if DocuMind available)
-```bash
-# Execute the AI orchestrator for dual-purpose generation
-node .documind/scripts/ai-orchestrator.js [command] [parameters]
-```
-
-### 3. Result Processing
-- Parse the JSON output from the orchestrator
-- Present a summary showing both human and AI documentation created
-- Highlight the comprehensive nature of the generation
-- Show file counts, locations, and any relevant metrics
-
-### 4. Fallback (if DocuMind not available)
-If DocuMind is not detected, fall back to using your native documentation capabilities and suggest DocuMind installation.
-
-## Example Workflow
-
-When user requests: `/document bootstrap`
-
-1. **Check availability**: Run detect-documind.js
-2. **Execute orchestrator**: `node .documind/scripts/ai-orchestrator.js bootstrap`
-3. **Present results**:
-   ```
-   ✅ Complete documentation generated successfully!
-
-   📚 Human Documentation:
-   - Created 8 documentation files in /docs/
-   - Generated organized structure with navigation
-
-   🤖 AI Documentation:
-   - Created 8 AI-optimized files in /docs/ai/
-   - Total tokens: 12,450
-   - Updated AI_README.md index
-
-   🔗 Both types of documentation are now available and automatically linked.
-   ```
-
-## Advanced Options
-
-Support these additional parameters when available:
-- `--concept [name]` for expand commands
-- `--integration [name]` for analyze commands
-- `--section [name]` for update commands
-- `--query [text]` for search commands
-
-## Error Handling
-
-If the orchestrator fails:
-1. Check the error message in the JSON response
-2. Suggest appropriate remediation steps
-3. Fall back to native documentation if needed
-
----
-
-**Key Principle**: Make documentation generation seamless and comprehensive. Users should get both human and AI documentation automatically without needing to understand the technical implementation.
+**Core principle**: Deliver comprehensive, dual-purpose documentation experiences without relying on local Node scripts. Let the `/document` commands and documented behaviors drive every interaction.

--- a/src/templates/ai-configs/copilot-prompt.md
+++ b/src/templates/ai-configs/copilot-prompt.md
@@ -1,77 +1,91 @@
 Intelligent documentation command processor for DocuMind projects.
 
-This command provides flexible documentation management through predefined actions, free-form requests, or interactive assistance.
+This prompt assumes DocuMind's `/document` commands behave as defined in [`src/core/commands.md`](../../core/commands.md) and mirrored at `.documind/core/commands.md` when DocuMind is installed locally.
 
-## Command Usage
+## Core Processing Pattern
+1. Determine which `/document` intent the request maps to.
+2. Execute the command (or simulate its effects when automation is unavailable).
+3. Interpret the response, gather supporting context, and present results using the structure below.
+4. When command execution is impossible, perform the work manually—draft the necessary documentation, answer questions directly, and state that a manual fallback was used.
 
-The `/document` command supports three modes:
+## Command Modes
+Each mode is expressed with the consistent **Intent → Expected LLM actions → Output expectations** structure.
 
-### 1. Interactive Mode (No Arguments)
-```
-/document
-```
-- Checks if documentation exists in `/docs/`
-- If no docs: Offers to bootstrap initial documentation
-- If docs exist: Shows available commands and recent documentation
+### `/document` (no arguments)
+- **Intent**: Provide interactive assistance when the user invokes `/document` without parameters.
+- **Expected LLM actions**:
+  1. Check whether documentation already exists in `/docs/` to tailor guidance.
+  2. Offer relevant next steps (bootstrap, expand, update, analyze, index, search) along with concise descriptions.
+  3. If automation is unavailable, manually summarize the current documentation state and propose next actions.
+- **Output expectations**:
+  - Present a friendly menu of available commands with short explanations.
+  - Call out recent documentation changes when known.
+  - Suggest the most relevant next command based on the user's context.
 
-### 2. Predefined Commands
-```
-/document bootstrap                    # Generate complete project documentation
-/document expand [concept]             # Create/expand concept documentation
-/document update [section]             # Update existing documentation section
-/document analyze [integration]        # Document external service integration
-/document index                        # Rebuild navigation and cross-references
-/document search [query]               # Search existing documentation
-```
+### `/document bootstrap`
+- **Intent**: Generate the comprehensive documentation set for the project.
+- **Expected LLM actions**:
+  1. Execute `/document bootstrap`.
+  2. Review the produced structure to identify major sections and indexes.
+  3. If the command cannot run, craft a manual starter documentation suite (overview, setup, architecture, integrations, contribution).
+- **Output expectations**:
+  - Summarize new or updated files, navigation assets, and any follow-up recommendations.
+  - Clarify whether automation or manual drafting produced the result.
 
-### 3. Free-Form Requests (Recommended!)
-```
-/document [free-form message]
-```
+### `/document expand [concept]`
+- **Intent**: Create or enrich documentation for a particular concept or feature.
+- **Expected LLM actions**:
+  1. Invoke `/document expand <concept>` with a descriptive label drawn from the request.
+  2. Validate that the resulting docs cover purpose, architecture, workflows, and examples.
+  3. When automation fails, research the repository manually and author the concept documentation.
+- **Output expectations**:
+  - Provide a concise concept summary, key implementation references, and next steps.
+  - Mention the specific files that now contain the expanded content.
 
-**Examples:**
-- `/document let's update the docs about the database`
-- `/document walk me through an API request to /saveStudent`
-- `/document how do we handle user authentication?`
-- `/document create a troubleshooting guide for deployment issues`
-- `/document explain the payment flow with examples`
-- `/document document the new notification system we just built`
+### `/document update [section]`
+- **Intent**: Refresh an existing documentation section to match current behavior.
+- **Expected LLM actions**:
+  1. Run `/document update <section>`.
+  2. Compare new guidance against previous information to ensure accuracy.
+  3. If automation cannot execute, perform the update manually using repository insights.
+- **Output expectations**:
+  - Describe what changed, note any lingering issues, and reference the updated files.
 
-## Processing Logic
+### `/document analyze [integration]`
+- **Intent**: Document how the project integrates with an external system or dependency.
+- **Expected LLM actions**:
+  1. Execute `/document analyze <integration>`.
+  2. Review configuration, API usage, and error-handling guidance produced by the command.
+  3. When unavailable, inspect the codebase manually and author the integration guide yourself.
+- **Output expectations**:
+  - Summarize integration purpose, setup steps, environment variables, and key code paths.
+  - Flag any risks or follow-up work uncovered during analysis.
 
-When processing `/document` commands, follow this logic:
+### `/document index`
+- **Intent**: Rebuild navigation, tables of contents, and cross-references for the docs set.
+- **Expected LLM actions**:
+  1. Run `/document index`.
+  2. Confirm that navigation artifacts reflect the current documentation inventory.
+  3. Without automation, audit navigation files manually and update links.
+- **Output expectations**:
+  - List the navigation or index files adjusted and note any remaining link issues.
 
-### Step 1: Parse Arguments
-1. **No arguments** → Enter interactive mode
-2. **First word matches predefined command** (bootstrap, expand, update, analyze, index, search) → Execute specific command
-3. **Anything else** → Treat as free-form request
+### `/document search [query]`
+- **Intent**: Locate existing documentation relevant to a user query.
+- **Expected LLM actions**:
+  1. Call `/document search <query>`.
+  2. Review the results and extract high-signal excerpts.
+  3. If the command is unavailable, manually examine `/docs/` and related code to answer the question.
+- **Output expectations**:
+  - Provide ranked findings with file paths, brief summaries, and recommendations for missing coverage if any.
 
-### Step 2: Interactive Mode (No Arguments)
-Check for existing documentation and provide appropriate guidance.
+## Natural Language Mapping
+Map free-form phrases such as "Document this feature", "Update the deployment guide", "How do we use Stripe?", "Fix the docs navigation", and "Find docs about authentication" to the corresponding `/document` commands above. Always confirm the mapping with the user when ambiguity exists.
 
-### Step 3: Free-Form Request Processing
-1. **Interpret Intent** - Analyze the request to determine user goals
-2. **Confirm Action Plan** - Present clear plan before execution
-3. **Research if Needed** - Search codebase and existing docs
-4. **Execute Action** - Perform documentation updates
+## Fallback Expectations
+If DocuMind automation is unavailable:
+- State that a manual drafting path is being used.
+- Produce the requested documentation directly, citing relevant files or observations.
+- Encourage installation or repair of DocuMind and reference `.documind/core/commands.md` for the definitive command definitions.
 
-### Step 4: Knowledge Base Queries
-For help requests, search documentation first, then research codebase if needed.
-
-## DocuMind System Instructions
-
-**For complete system instructions, see `.documind/core/system.md`**
-
-## Available Commands Reference
-
-**For detailed command reference, see `.documind/core/commands.md`**
-
-## Smart Help System
-
-The `/document` command acts as an intelligent help system that can:
-- Answer questions about the codebase
-- Research and explain functionality
-- Proactively suggest documentation improvements
-- Provide guided assistance for complex topics
-
-**Remember**: Every interaction should either provide immediate help or improve the project's documentation for future use.
+**Goal**: Deliver a consistent, LLM-friendly documentation experience centered on the `/document` commands without referencing local Node scripts.

--- a/src/templates/ai-configs/cursor-rules.md
+++ b/src/templates/ai-configs/cursor-rules.md
@@ -1,115 +1,83 @@
-# DocuMind Documentation System
+# Cursor Configuration
 
-This repository uses DocuMind for intelligent documentation management with automatic dual-purpose generation.
+Cursor agents manage documentation through DocuMind's `/document` commands. Follow the behaviors defined in [`src/core/commands.md`](../../core/commands.md) and, when running locally, the synchronized reference at `.documind/core/commands.md`.
 
-## Automatic Dual-Purpose Generation
+## Standard Operating Sequence
+1. Detect the user's intent and map it to a `/document` command.
+2. Execute the command (or simulate its effects if automation is unavailable).
+3. Review outputs and supporting repository context.
+4. Respond using the intent/action/output format described below.
+5. When commands cannot run, create the requested documentation manually and note that a fallback was used.
 
-When users request documentation, DocuMind automatically generates BOTH human-readable and AI-optimized documentation in a single operation. This provides comprehensive documentation coverage without additional complexity for users.
+## Command Reference
+Each command entry maintains the **Intent → Expected LLM actions → Output expectations** structure for consistency.
 
-## Documentation Commands
+### `/document bootstrap`
+- **Intent**: Build or refresh the complete documentation suite.
+- **Expected LLM actions**:
+  1. Run `/document bootstrap`.
+  2. Inspect resulting documentation directories and indexes.
+  3. If automation is unavailable, author a manual overview covering project introduction, setup, architecture, integrations, and contribution guidelines.
+- **Output expectations**:
+  - Summarize new or updated documentation and navigation assets.
+  - Suggest additional follow-up commands if coverage gaps remain.
 
-Execute the DocuMind AI orchestrator for ALL documentation requests to generate both human and AI documentation:
+### `/document expand [concept]`
+- **Intent**: Produce detailed documentation for a specific concept, feature, or workflow.
+- **Expected LLM actions**:
+  1. Execute `/document expand <concept>` using a descriptive name.
+  2. Verify that generated docs explain purpose, architecture, usage, and examples.
+  3. If the command cannot run, research the relevant files and draft the concept documentation manually.
+- **Output expectations**:
+  - Provide a concise summary of the concept and note where the documentation lives.
+  - Recommend related topics that might benefit from additional coverage.
 
-- `/document bootstrap` - Generate complete project documentation (both types)
-- `/document expand [concept]` - Expand documentation for specific concepts
-- `/document update [section]` - Update existing documentation sections
-- `/document analyze [integration]` - Document external service integrations
-- `/document index` - Regenerate documentation navigation
-- `/document search [query]` - Find existing documentation
+### `/document update [section]`
+- **Intent**: Refresh an existing documentation section with current information.
+- **Expected LLM actions**:
+  1. Call `/document update <section>`.
+  2. Compare new content with previous guidance to ensure accuracy.
+  3. When automation fails, update the section manually using repository insights.
+- **Output expectations**:
+  - Describe the adjustments made and reference the affected files.
+  - Capture any open issues uncovered during the update.
 
-## Natural Language Support
+### `/document analyze [integration]`
+- **Intent**: Document interactions with an external service or dependency.
+- **Expected LLM actions**:
+  1. Run `/document analyze <integration>` with the relevant service name.
+  2. Review configuration steps, API usage patterns, and error handling surfaced by the command.
+  3. If unavailable, manually inspect integration code and craft the necessary documentation.
+- **Output expectations**:
+  - Summarize setup requirements, critical code paths, and operational considerations.
+  - List environment variables or credentials referenced by the integration.
 
-Recognize these patterns as documentation requests and execute the orchestrator:
-- "Document this component" → `/document expand [component]`
-- "Update the README" → `/document update readme`
-- "How do we integrate with Stripe?" → `/document analyze stripe`
-- "Create setup instructions" → `/document expand setup`
-- "Generate all documentation" → `/document bootstrap`
+### `/document index`
+- **Intent**: Rebuild documentation navigation and cross-references.
+- **Expected LLM actions**:
+  1. Execute `/document index`.
+  2. Ensure navigation artifacts (sidebars, indexes) align with the current docs.
+  3. Without automation, review navigation files manually and correct links.
+- **Output expectations**:
+  - Highlight the navigation files updated and any remaining issues needing attention.
 
-## Execution Instructions
+### `/document search [query]`
+- **Intent**: Locate existing documentation relevant to a specific topic.
+- **Expected LLM actions**:
+  1. Invoke `/document search <query>`.
+  2. Analyze the results, collecting excerpts when helpful.
+  3. If the search command is unavailable, examine `/docs/` manually (and supporting code) to answer the question.
+- **Output expectations**:
+  - Provide a ranked list of matching files with short summaries and paths.
+  - Note gaps where new documentation would add value.
 
-For ANY documentation command, follow this automated workflow:
+## Language Mapping and Support
+- Treat phrases such as "Document this component", "Update the README", "How do we integrate Stripe?", "Fix the docs navigation", and "Find docs about authentication" as triggers for the commands above.
+- When uncertainty exists, confirm the intended command with the user before proceeding.
 
-### 1. Detection Phase
-```bash
-# Always check DocuMind availability first
-node .documind/scripts/detect-documind.js ai-report
-```
+## Fallback Responsibilities
+- If `/document` automation is unavailable, Cursor must still produce the requested documentation manually.
+- Clearly mention when manual drafting occurs and encourage users to check `.documind/core/commands.md` for authoritative command semantics.
+- Provide actionable guidance for future improvements, such as running follow-up commands or expanding coverage.
 
-### 2. Orchestration Phase (if DocuMind available)
-```bash
-# Execute appropriate command through orchestrator
-node .documind/scripts/ai-orchestrator.js [command] [parameters]
-
-# Examples:
-node .documind/scripts/ai-orchestrator.js bootstrap
-node .documind/scripts/ai-orchestrator.js expand authentication
-node .documind/scripts/ai-orchestrator.js analyze stripe-integration
-node .documind/scripts/ai-orchestrator.js update getting-started
-node .documind/scripts/ai-orchestrator.js index
-node .documind/scripts/ai-orchestrator.js search "api endpoints"
-```
-
-### 3. Result Presentation
-Process the JSON output and present comprehensive results:
-- **Human Documentation**: Files created in `/docs/` with organized structure
-- **AI Documentation**: AI-optimized files in `/docs/ai/` with token counts
-- **Navigation**: Updated cross-references and index files
-- **Summary**: Total files, locations, and generation metrics
-
-### 4. Fallback Handling
-If DocuMind is not detected:
-1. Use Cursor's native documentation capabilities
-2. Inform user about enhanced dual-purpose generation available with DocuMind
-3. Provide installation guidance if requested
-
-## Example Workflow
-
-User: "Document the authentication system"
-
-1. **Detect**: `node .documind/scripts/detect-documind.js ai-report`
-2. **Execute**: `node .documind/scripts/ai-orchestrator.js expand authentication`
-3. **Present**:
-   ```
-   ✅ Authentication documentation generated successfully!
-
-   📚 Human Documentation:
-   - /docs/02-core-concepts/authentication.md
-   - Complete user guide with examples
-
-   🤖 AI Documentation:
-   - /docs/ai/authentication-concept-ai.md
-   - Optimized for AI consumption (2,850 tokens)
-   - Added to AI master index
-
-   Both versions are now available and automatically linked.
-   ```
-
-## Command Parameter Mapping
-
-- `/document bootstrap` → `bootstrap` (no parameters)
-- `/document expand [concept]` → `expand [concept]`
-- `/document analyze [service]` → `analyze [service]`
-- `/document update [section]` → `update [section]`
-- `/document index` → `index` (no parameters)
-- `/document search [query]` → `search [query]`
-
-## Error Recovery
-
-If orchestrator execution fails:
-1. Parse error details from JSON response
-2. Suggest specific remediation based on error type
-3. Fall back to Cursor's built-in documentation tools
-4. Maintain user productivity regardless of DocuMind status
-
-## Integration Benefits
-
-The automatic dual-purpose generation provides:
-- **Developers**: Human-readable docs in standard format
-- **AI Tools**: Optimized content for better context understanding
-- **Teams**: Consistent documentation across all use cases
-- **Maintenance**: Single command updates both documentation types
-
----
-
-**Core Principle**: Make comprehensive documentation generation completely transparent. Users get both human and AI documentation automatically without needing to understand the underlying dual-purpose architecture.
+**Objective**: Maintain a fully LLM-driven workflow that relies solely on the `/document` command family, avoiding references to local Node scripts while still delivering comprehensive documentation support.

--- a/src/templates/ai-configs/gemini.md
+++ b/src/templates/ai-configs/gemini.md
@@ -1,130 +1,82 @@
 # Gemini CLI Instructions
 
-This repository uses **DocuMind** for intelligent documentation management with automatic dual-purpose generation.
+Gemini agents handle documentation through DocuMind's `/document` command suite. Behaviors are defined in [`src/core/commands.md`](../../core/commands.md) and mirrored for local use at `.documind/core/commands.md`.
 
-## Automatic Dual-Purpose Documentation
+## Execution Blueprint
+1. Map the user request to a `/document` intent.
+2. Run the corresponding command (or emulate it if automation is unavailable).
+3. Review command output alongside repository context.
+4. Respond using the standardized intent/action/output format.
+5. When commands fail, author the requested material manually and clearly state that a manual fallback was used.
 
-When users request documentation, DocuMind automatically generates BOTH human-readable and AI-optimized documentation simultaneously. This comprehensive approach ensures complete documentation coverage without requiring users to understand the technical implementation.
+## Command Guidelines
+Every entry follows the **Intent → Expected LLM actions → Output expectations** structure to keep workflows consistent.
 
-## Documentation Commands
+### `/document bootstrap`
+- **Intent**: Generate the full documentation suite from scratch or refresh it comprehensively.
+- **Expected LLM actions**:
+  1. Execute `/document bootstrap`.
+  2. Examine generated directories, indexes, and summary information.
+  3. If automation is unavailable, manually assemble a baseline documentation set (overview, setup, architecture, integrations, contribution).
+- **Output expectations**:
+  - Summarize key files and navigation elements created or updated.
+  - Highlight any remaining tasks or suggested follow-up commands.
 
-For ALL documentation requests, execute the DocuMind AI orchestrator to generate both human and AI documentation:
+### `/document expand [concept]`
+- **Intent**: Create or deepen documentation for a specific concept, feature, or workflow.
+- **Expected LLM actions**:
+  1. Run `/document expand <concept>` with a descriptive label.
+  2. Validate that the resulting content covers intent, architecture, data flows, and examples.
+  3. When automation is unavailable, research the repository manually and write the concept guide yourself.
+- **Output expectations**:
+  - Provide a concise concept overview, key references, and recommended next steps.
+  - Note the file paths that contain the expanded material.
 
-- `/document bootstrap` - Generate complete project documentation (both types)
-- `/document expand [concept]` - Create detailed documentation for concepts
-- `/document update [section]` - Refresh existing documentation sections
-- `/document analyze [integration]` - Document external service integrations
-- `/document index` - Rebuild documentation navigation and links
-- `/document search [query]` - Search existing documentation
+### `/document update [section]`
+- **Intent**: Refresh an existing documentation section to ensure accuracy.
+- **Expected LLM actions**:
+  1. Invoke `/document update <section>`.
+  2. Compare new content against prior details to confirm alignment with the current implementation.
+  3. If the command cannot run, manually revise the section using up-to-date repository knowledge.
+- **Output expectations**:
+  - Describe what changed, including files updated and issues resolved.
+  - Identify any follow-up work still needed.
+
+### `/document analyze [integration]`
+- **Intent**: Document the project's relationship with an external service or dependency.
+- **Expected LLM actions**:
+  1. Execute `/document analyze <integration>`.
+  2. Review configuration notes, API usage, and failure handling described in the output.
+  3. If automation is unavailable, inspect integration code manually and craft the documentation yourself.
+- **Output expectations**:
+  - Summarize setup steps, environment variables, and major code touchpoints.
+  - Call out risks, limitations, or monitoring considerations.
+
+### `/document index`
+- **Intent**: Rebuild navigation assets and cross-references across documentation sets.
+- **Expected LLM actions**:
+  1. Run `/document index`.
+  2. Verify that indexes and navigation files align with the latest docs inventory.
+  3. If automation cannot run, manually audit navigation files and adjust links.
+- **Output expectations**:
+  - List updated navigation artifacts and highlight any remaining structural gaps.
+
+### `/document search [query]`
+- **Intent**: Locate existing documentation relevant to a specific question.
+- **Expected LLM actions**:
+  1. Call `/document search <query>`.
+  2. Analyze returned matches, extracting concise summaries or excerpts.
+  3. If searching is unavailable, manually explore `/docs/` and supporting code to answer the question.
+- **Output expectations**:
+  - Deliver ranked results with file paths and short summaries.
+  - Point out missing coverage that may warrant future documentation.
 
 ## Natural Language Recognition
+Recognize phrases such as "Generate project docs", "Document the authentication flow", "Update the API guide", "How do we use Stripe?", "Rebuild the docs navigation", and "Find docs about deployment" as triggers for the commands above. Confirm intent with the user if ambiguity remains.
 
-Recognize these patterns as documentation requests and execute the orchestrator:
+## Fallback Responsibilities
+- When `/document` automation fails, Gemini must still fulfill the request by drafting the necessary documentation manually.
+- Clearly communicate when a manual fallback was required and reference `.documind/core/commands.md` for the authoritative command definitions.
+- Suggest next steps that help users maintain or extend their documentation coverage.
 
-- "Document this feature" → `/document expand [feature]`
-- "Update the installation guide" → `/document update installation`
-- "How do we use MongoDB?" → `/document analyze mongodb`
-- "Create API documentation" → `/document expand api`
-- "Generate project docs" → `/document bootstrap`
-- "Find docs about authentication" → `/document search authentication`
-
-## Execution Protocol
-
-For ANY documentation command, follow this standardized workflow:
-
-### 1. DocuMind Detection
-```bash
-# Check if DocuMind is properly installed and available
-node .documind/scripts/detect-documind.js ai-report
-```
-
-### 2. Orchestrated Execution (if DocuMind available)
-```bash
-# Execute the appropriate command via AI orchestrator
-node .documind/scripts/ai-orchestrator.js [command] [parameters]
-
-# Command examples:
-node .documind/scripts/ai-orchestrator.js bootstrap
-node .documind/scripts/ai-orchestrator.js expand user-authentication
-node .documind/scripts/ai-orchestrator.js analyze payment-processing
-node .documind/scripts/ai-orchestrator.js update api-reference
-node .documind/scripts/ai-orchestrator.js index
-node .documind/scripts/ai-orchestrator.js search "database schema"
-```
-
-### 3. Comprehensive Result Presentation
-Parse the orchestrator's JSON output and present detailed results:
-- **Human Documentation**: Files generated in `/docs/` with clear organization
-- **AI Documentation**: AI-optimized content in `/docs/ai/` with token metrics
-- **Cross-References**: Updated navigation and linking between both documentation types
-- **Generation Summary**: File counts, locations, and processing statistics
-
-### 4. Graceful Fallback
-If DocuMind is not available:
-1. Acknowledge the documentation request
-2. Use Gemini's built-in documentation capabilities
-3. Explain the enhanced dual-purpose generation available with DocuMind
-4. Offer installation guidance if requested
-
-## Command Execution Examples
-
-### Bootstrap Documentation
-User: `/document bootstrap` or "Generate all project documentation"
-
-1. **Check**: `node .documind/scripts/detect-documind.js ai-report`
-2. **Execute**: `node .documind/scripts/ai-orchestrator.js bootstrap`
-3. **Present Results**:
-   ```
-   ✅ Complete documentation suite generated successfully!
-
-   📚 Human Documentation (8 files):
-   - /docs/01-getting-oriented/project-overview.md
-   - /docs/02-core-concepts/ (4 concept files)
-   - /docs/03-integrations/ (2 integration files)
-   - /docs/04-development/contributing.md
-
-   🤖 AI Documentation (8 files):
-   - /docs/ai/ (AI-optimized versions)
-   - Total tokens: 15,250
-   - Updated AI_README.md master index
-
-   Both documentation types are now available and cross-linked.
-   ```
-
-### Expand Concept
-User: `/document expand authentication` or "Document the authentication system"
-
-1. **Check**: `node .documind/scripts/detect-documind.js ai-report`
-2. **Execute**: `node .documind/scripts/ai-orchestrator.js expand authentication`
-3. **Present Results**: Show both human and AI documentation files created for the authentication concept
-
-## Parameter Handling
-
-Support these command parameters:
-- **expand**: Concept name as second argument
-- **analyze**: Integration/service name as second argument
-- **update**: Section name as second argument
-- **search**: Query string as second argument
-- **bootstrap** and **index**: No additional parameters required
-
-## Error Management
-
-If orchestrator execution encounters issues:
-1. Parse error details from the JSON response
-2. Provide context-specific troubleshooting guidance
-3. Suggest remediation steps based on the error type
-4. Fall back to Gemini's native documentation generation
-5. Ensure user productivity is maintained regardless of DocuMind status
-
-## Output Quality Standards
-
-Ensure all generated documentation meets these standards:
-- **Accuracy**: Content reflects actual codebase and functionality
-- **Completeness**: Both human and AI versions cover all necessary aspects
-- **Consistency**: Formatting and structure follow established patterns
-- **Accessibility**: Human docs are readable, AI docs are optimally structured
-- **Maintenance**: Documentation is easy to update and extend
-
----
-
-**Primary Objective**: Deliver comprehensive documentation automatically. Users should receive both human-readable and AI-optimized documentation through a single, simple command interface, with the dual-purpose generation being completely transparent to them.
+**Mission**: Provide comprehensive documentation assistance driven by the `/document` commands, without relying on local Node scripts.

--- a/src/templates/documentation-workflows.md
+++ b/src/templates/documentation-workflows.md
@@ -1,329 +1,90 @@
 # DocuMind Documentation Workflows
 
-## Overview
-
-This guide explains the automatic dual-purpose documentation generation workflows that AI agents execute when users request documentation. DocuMind generates both human-readable and AI-optimized documentation seamlessly through a single command interface.
-
-## Core Workflow Architecture
-
-```mermaid
-flowchart TD
-    A[User Request] --> B[AI Agent Recognition]
-    B --> C{DocuMind Available?}
-    C -->|Yes| D[Execute Orchestrator]
-    C -->|No| E[Fallback to Native]
-
-    D --> F[Detection Phase]
-    F --> G[Command Execution]
-    G --> H[Dual Generation]
-
-    H --> I[Human Docs<br>/docs/]
-    H --> J[AI Docs<br>/docs/ai/]
-
-    I --> K[Update Navigation]
-    J --> L[Update AI Index]
-
-    K --> M[Present Results]
-    L --> M
-    E --> M
-```
-
-## Workflow Types
-
-### 1. Bootstrap Workflow
-
-**Purpose**: Generate complete project documentation structure
-
-**User Triggers**:
-- `/document bootstrap`
-- "Generate all project documentation"
-- "Create complete documentation"
-
-**Execution Flow**:
-1. **Detection**: Check DocuMind availability
-2. **Orchestration**: Execute `ai-orchestrator.js bootstrap`
-3. **Generation**:
-   - Process all available manifests
-   - Generate human documentation in `/docs/`
-   - Generate AI documentation in `/docs/ai/`
-   - Create directory structure (01-getting-oriented, 02-core-concepts, etc.)
-4. **Indexing**: Update AI_README.md master index
-5. **Presentation**: Show comprehensive results
-
-**Expected Output**:
-```
-✅ Complete documentation suite generated!
-
-📚 Human Documentation (8 files):
-- /docs/01-getting-oriented/project-overview.md
-- /docs/02-core-concepts/ (4 concept files)
-- /docs/03-integrations/ (2 integration files)
-- /docs/04-development/contributing.md
-
-🤖 AI Documentation (8 files):
-- /docs/ai/ (AI-optimized versions)
-- Total tokens: 15,250
-- Updated AI_README.md master index
-
-📊 Generation Summary:
-- Duration: 2.3 seconds
-- Human docs: 8 files
-- AI docs: 8 files
-- Total tokens: 15,250
-```
-
-### 2. Concept Expansion Workflow
-
-**Purpose**: Create detailed documentation for specific concepts
-
-**User Triggers**:
-- `/document expand [concept]`
-- "Document the authentication system"
-- "Create documentation for user management"
-
-**Execution Flow**:
-1. **Detection**: Verify DocuMind availability
-2. **Orchestration**: Execute `ai-orchestrator.js expand [concept]`
-3. **Manifest Selection**: Find relevant concept manifests
-4. **Generation**:
-   - Generate human concept documentation
-   - Generate AI-optimized concept documentation
-   - Apply concept-specific variables
-5. **Indexing**: Update master index with new concept
-6. **Presentation**: Show focused concept results
-
-**Example Execution**:
-```bash
-# User: "Document the authentication system"
-node .documind/scripts/ai-orchestrator.js expand authentication
-```
-
-**Expected Output**:
-```
-✅ Authentication concept documented successfully!
-
-📚 Human Documentation:
-- /docs/02-core-concepts/authentication.md
-- Complete guide with examples and implementation details
-
-🤖 AI Documentation:
-- /docs/ai/authentication-concept-ai.md
-- Optimized for AI consumption (2,850 tokens)
-- Added to AI master index
-
-🔗 Cross-references updated in navigation
-```
-
-### 3. Integration Analysis Workflow
-
-**Purpose**: Document external service integrations
-
-**User Triggers**:
-- `/document analyze [service]`
-- "How do we use Stripe?"
-- "Document the MongoDB integration"
-
-**Execution Flow**:
-1. **Detection**: Check system readiness
-2. **Orchestration**: Execute `ai-orchestrator.js analyze [service]`
-3. **Integration Focus**: Use integration-specific manifests
-4. **Generation**:
-   - Create service integration documentation
-   - Generate API usage examples
-   - Document configuration and setup
-5. **Categorization**: Place in `/docs/03-integrations/`
-6. **Presentation**: Show integration-specific results
-
-### 4. Section Update Workflow
-
-**Purpose**: Refresh existing documentation sections
-
-**User Triggers**:
-- `/document update [section]`
-- "Update the API documentation"
-- "Refresh the getting started guide"
-
-**Execution Flow**:
-1. **Detection**: Verify DocuMind status
-2. **Orchestration**: Execute `ai-orchestrator.js update [section]`
-3. **Section Identification**: Locate existing documentation
-4. **Regeneration**:
-   - Refresh human documentation
-   - Update AI-optimized versions
-   - Maintain existing structure
-5. **Synchronization**: Update cross-references
-6. **Presentation**: Show update summary
-
-### 5. Index Rebuild Workflow
-
-**Purpose**: Regenerate documentation navigation and cross-references
-
-**User Triggers**:
-- `/document index`
-- "Rebuild documentation index"
-- "Update navigation"
-
-**Execution Flow**:
-1. **Detection**: Confirm system availability
-2. **Orchestration**: Execute `ai-orchestrator.js index`
-3. **Scanning**: Analyze existing documentation structure
-4. **Index Generation**:
-   - Rebuild AI_README.md master index
-   - Update navigation files
-   - Refresh cross-references
-5. **Validation**: Verify link integrity
-6. **Presentation**: Show indexing results
-
-### 6. Search Workflow
-
-**Purpose**: Find existing documentation content
-
-**User Triggers**:
-- `/document search [query]`
-- "Find documentation about databases"
-- "Search for API endpoints"
-
-**Execution Flow**:
-1. **Detection**: Check search capabilities
-2. **Orchestration**: Execute `ai-orchestrator.js search [query]`
-3. **Content Scanning**:
-   - Search human documentation
-   - Search AI documentation
-   - Identify relevant matches
-4. **Result Compilation**: Aggregate findings
-5. **Presentation**: Show search results with context
-
-## Error Recovery Workflows
-
-### 1. DocuMind Not Available
-
-**Scenario**: Detection shows DocuMind is not installed
-
-**Recovery Flow**:
-1. **Acknowledge**: Recognize the documentation request
-2. **Fallback**: Use AI agent's native documentation capabilities
-3. **Suggestion**: Recommend DocuMind installation
-4. **Guidance**: Provide installation instructions if requested
-
-**Example Response**:
-```
-📝 Documentation request acknowledged
-
-⚠️  DocuMind not detected - using native capabilities
-💡 For enhanced dual-purpose generation, install DocuMind:
-   npx @dennis-webb/documind init
-
-📚 Generated basic documentation using Claude's capabilities
-```
-
-### 2. Orchestrator Execution Failure
-
-**Scenario**: AI orchestrator script encounters errors
-
-**Recovery Flow**:
-1. **Error Parsing**: Analyze JSON error response
-2. **Context Assessment**: Determine error type and cause
-3. **Remediation**: Provide specific troubleshooting steps
-4. **Fallback**: Continue with alternative approach
-5. **User Support**: Offer additional assistance
-
-**Example Error Handling**:
-```json
-{
-  "success": false,
-  "error": "DocuMind installation incomplete: .documind/core not found",
-  "suggestions": [
-    "Run DocuMind update: npx @dennis-webb/documind update",
-    "Verify installation: ls -la .documind/"
-  ]
-}
-```
-
-### 3. Partial Generation Failure
-
-**Scenario**: Some documentation generates successfully, others fail
-
-**Recovery Flow**:
-1. **Success Tracking**: Identify what was generated successfully
-2. **Failure Analysis**: Catalog what failed and why
-3. **Partial Results**: Present successful documentation
-4. **Issue Resolution**: Provide specific fixes for failures
-5. **Retry Option**: Offer to retry failed components
-
-## Workflow Optimization
-
-### Performance Considerations
-
-1. **Caching**: Cache detection results during session
-2. **Parallel Execution**: Generate human and AI docs simultaneously
-3. **Incremental Updates**: Only regenerate changed content
-4. **Resource Management**: Monitor token usage and file sizes
-
-### Quality Assurance
-
-1. **Validation**: Verify generated content meets standards
-2. **Cross-Reference**: Ensure links and navigation work correctly
-3. **Consistency**: Maintain formatting and structure standards
-4. **Completeness**: Verify all requested documentation is generated
-
-### User Experience
-
-1. **Progress Indication**: Show generation progress for long operations
-2. **Clear Results**: Present outcomes with visual differentiation
-3. **Error Communication**: Provide actionable error messages
-4. **Fallback Transparency**: Clearly indicate when fallbacks are used
-
-## Integration Patterns
-
-### Natural Language Processing
-
-AI agents should recognize these patterns and map them to workflows:
-
-| User Input | Detected Intent | Workflow |
-|------------|----------------|----------|
-| "Document everything" | Complete generation | Bootstrap |
-| "Explain authentication" | Concept documentation | Expand |
-| "How does Stripe work here?" | Integration analysis | Analyze |
-| "Update the API guide" | Section refresh | Update |
-| "Fix the navigation" | Index rebuild | Index |
-| "Find database docs" | Content search | Search |
-
-### Command Parameter Extraction
-
-Extract parameters from natural language:
-
-- **Concept names**: "authentication", "user management", "data flow"
-- **Service names**: "stripe", "mongodb", "redis", "aws"
-- **Section names**: "api", "getting-started", "installation"
-- **Search queries**: "database schema", "api endpoints", "configuration"
-
-### Result Formatting
-
-Standardize result presentation across all AI agents:
-
-1. **Success indicators**: ✅ for completion, ⚠️ for warnings
-2. **Content categorization**: 📚 for human docs, 🤖 for AI docs
-3. **Metrics display**: File counts, token counts, duration
-4. **Action summaries**: What was created, updated, or found
-
-## Best Practices
-
-### For AI Agent Developers
-
-1. **Always detect first**: Check DocuMind availability before assuming capability
-2. **Parse JSON responses**: Handle structured output from orchestrator
-3. **Provide fallbacks**: Ensure functionality without DocuMind
-4. **Show comprehensive results**: Highlight dual-purpose generation
-5. **Handle errors gracefully**: Provide actionable troubleshooting
-
-### For Users
-
-1. **Use natural language**: AI agents recognize documentation intents
-2. **Be specific**: Provide concept/service names for targeted documentation
-3. **Check results**: Review both human and AI documentation generated
-4. **Update regularly**: Keep documentation current with code changes
-5. **Leverage search**: Use search workflow to find existing content
-
-## Conclusion
-
-The DocuMind workflows enable AI agents to provide comprehensive documentation generation automatically. By following these patterns, AI agents deliver both human-readable and AI-optimized documentation through simple, natural language commands, making the dual-purpose generation transparent to users while ensuring complete documentation coverage.
+DocuMind centralizes documentation automation through the `/document` command family. The authoritative behavior for each command lives in [`src/core/commands.md`](../core/commands.md) and is mirrored at `.documind/core/commands.md` when DocuMind is installed locally.
+
+## Standard Workflow Format
+Every documentation workflow follows the same structure:
+- **Intent**: What the user is trying to accomplish.
+- **Expected LLM actions**: Steps the assistant should perform, including when to call `/document …` commands and how to respond if automation is unavailable.
+- **Output expectations**: The information the assistant returns to the user, including summaries, file references, and follow-up suggestions.
+
+When `/document` commands cannot run (e.g., automation missing or failing), the assistant should carry out the work manually, create the requested documentation directly, and clearly communicate that a fallback approach was used.
+
+## Workflows by Command
+
+### `/document bootstrap`
+- **Intent**: Create or refresh the entire documentation suite for the project.
+- **Expected LLM actions**:
+  1. Execute `/document bootstrap` to generate the baseline documentation set.
+  2. Review the resulting structure, noting new or updated files, navigation assets, and indexes.
+  3. If automation is unavailable, manually draft core documents covering project overview, setup, architecture, integrations, and contribution guidelines.
+- **Output expectations**:
+  - Summarize the generated documentation, highlighting directory structure and key files.
+  - Call out navigation or index updates and recommend next steps if coverage gaps remain.
+
+### `/document expand [concept]`
+- **Intent**: Produce or enrich documentation for a specific concept, component, or workflow.
+- **Expected LLM actions**:
+  1. Run `/document expand <concept>` using a descriptive label.
+  2. Examine the resulting content to ensure it explains purpose, architecture, workflows, and examples.
+  3. If the command fails, research the repository manually and author the concept documentation yourself.
+- **Output expectations**:
+  - Provide a concise concept summary with key insights and related file paths.
+  - Suggest complementary topics or follow-up commands where appropriate.
+
+### `/document analyze [integration]`
+- **Intent**: Document how the project integrates with an external service or dependency.
+- **Expected LLM actions**:
+  1. Execute `/document analyze <integration>` with the relevant service name.
+  2. Review configuration, API usage, failure handling, and monitoring notes produced by the command.
+  3. When automation is unavailable, inspect integration code, environment variables, and existing docs to craft the guide manually.
+- **Output expectations**:
+  - Summarize setup steps, environment requirements, and key code references.
+  - Highlight operational considerations, risks, and follow-up recommendations.
+
+### `/document update [section]`
+- **Intent**: Refresh an existing documentation section to reflect the current state of the system.
+- **Expected LLM actions**:
+  1. Call `/document update <section>` for the targeted area.
+  2. Compare new guidance with previous instructions to confirm accuracy and completeness.
+  3. If automation fails, revise the section manually using recent code and documentation context.
+- **Output expectations**:
+  - Detail the updates made, including affected files and issues resolved.
+  - Note any outstanding questions or TODOs surfaced during the update.
+
+### `/document index`
+- **Intent**: Rebuild navigation, tables of contents, and cross-references across documentation.
+- **Expected LLM actions**:
+  1. Run `/document index` to regenerate navigation assets.
+  2. Verify that sidebars, indexes, and link structures match the latest documentation inventory.
+  3. If the command cannot execute, manually audit navigation files and adjust links to maintain consistency.
+- **Output expectations**:
+  - List updated navigation artifacts and identify any remaining structural issues.
+  - Recommend additional cleanup if broken links or orphaned docs persist.
+
+### `/document search [query]`
+- **Intent**: Locate existing documentation relevant to a user's question.
+- **Expected LLM actions**:
+  1. Invoke `/document search <query>`.
+  2. Analyze the returned matches, capturing concise excerpts when useful.
+  3. If searching is unavailable, manually review `/docs/` and supporting code to answer the question.
+- **Output expectations**:
+  - Provide a ranked summary of relevant documents with file paths.
+  - Point out gaps where new documentation could be added.
+
+## Natural Language Recognition
+Map free-form phrases (e.g., "Document everything", "Explain authentication", "How do we use Stripe?", "Update the API guide", "Fix the navigation", "Find database docs") to the appropriate `/document` command by intent. Confirm the mapping with the user when ambiguity exists.
+
+## Fallback Strategies
+When `/document` automation is not available or fails mid-run:
+1. **Acknowledge** the limitation and explain that a manual path will be used.
+2. **Perform the work manually**, drafting or updating the necessary documentation based on repository evidence.
+3. **Summarize the results** using the intent/action/output format, noting which parts were manually authored.
+4. **Recommend remediation**, such as reinstalling DocuMind, and refer users to `.documind/core/commands.md` for command semantics.
+
+## Quality and Presentation Standards
+- Use consistent success indicators (e.g., ✅ for completion, ⚠️ for warnings) when presenting results.
+- Separate human-readable documentation updates from AI-oriented outputs when both are relevant.
+- Include file paths, summaries, and next steps so users can quickly verify changes.
+
+**Outcome**: A clear, LLM-friendly guide to executing DocuMind workflows that depends solely on `/document` commands and direct assistant behavior—no local scripts required.


### PR DESCRIPTION
## Summary
- replace script-based directions across AI configuration templates with intent/action/output workflows built around `/document` commands
- ensure each template references the authoritative command guide and documents manual fallback behavior when automation is unavailable
- align the documentation workflow guide with the new structure so future updates only require changes to the central command reference

## Testing
- not run (documentation updates only)

------
https://chatgpt.com/codex/tasks/task_e_68dec09c21bc8321a775c310016e2158