### PR TITLE
Document /document review command workflow

### DIFF
--- a/docs/02-core-concepts/01-cli-system.md
+++ b/docs/02-core-concepts/01-cli-system.md
@@ -11,6 +11,7 @@ The `/document` command can be used in several ways:
     *   `bootstrap`: Generate documentation from scratch.
     *   `expand [concept]`: Add detail to a specific concept.
     *   `update [section]`: Refresh an existing section.
+    *   `review [scope]`: Audit docs against the implementation and stage follow-up fixes.
     *   `analyze [integration]`: Document an external service.
     *   `index`: Rebuild the navigation.
     *   `search [query]`: Search the documentation.
@@ -25,6 +26,8 @@ When a `/document` command is executed, the system follows these steps:
 3.  **Confirm Action Plan**: Before making changes, DocuMind presents a clear plan of action.
 4.  **Research**: The system may research the codebase or existing documentation to gather context.
 5.  **Execute**: The appropriate action is performed, such as creating or updating documentation files.
+
+During a `/document review` run, DocuMind inspects the relevant code, compares its findings with the statements inside `docs/`, and produces a findings report. The review itself does not modify files; instead, it recommends targeted `/document update …` prompts that are restricted to documentation files so you can apply corrections safely.
 
 This system is designed to be a "living documentation" that evolves with your codebase.
 

--- a/docs/_sidebar.md
+++ b/docs/_sidebar.md
@@ -24,6 +24,7 @@
 - **Expand**: `/document expand concept "[name]"`
 - **Analyze**: `/document analyze integration "[service]"`
 - **Update**: `/document update section "[section]"`
+- **Review**: `/document review "[scope]"` (audit docs vs. code)
 - **Bootstrap**: `/document bootstrap` (regenerate all)
 
 ### 🎯 Quick Actions

--- a/src/core/commands.md
+++ b/src/core/commands.md
@@ -43,6 +43,21 @@ Update existing documentation section with current information.
 - "Update the getting started guide"
 - "Refresh the deployment documentation"
 
+### /document review [scope]
+Audit existing documentation against the implementation.
+- Example: `/document review payments-guide`
+- Gathers current behavior evidence from the codebase
+- Compares findings with statements in `/docs/`
+- Summarizes mismatches and risks
+- Suggests targeted `/document update` follow-ups for fixes
+- Entirely driven by `/document` prompts with no direct edits to code or docs during the review phase
+
+**Usage:**
+- `/document review authentication`
+- `/document review docs/02-core-concepts/01-cli-system.md`
+- "Review the deployment guide for accuracy"
+- "Audit the API reference against the code"
+
 ### /document analyze [integration]
 Document external service integration or dependency.
 - Example: `/document analyze stripe-payments`
@@ -99,11 +114,17 @@ The AI should recognize these natural language variants and map them to the appr
 - "Add docs for [component]"
 - "Create documentation for [concept]"
 
-### Update Patterns  
+### Update Patterns
 - "Update the [section] docs"
 - "Refresh the [guide/readme]"
 - "Fix outdated documentation"
 - "Revise the [section] information"
+
+### Review Patterns
+- "Is this documentation accurate?"
+- "Audit the [section] guide"
+- "Review the docs for [feature]"
+- "Compare the documentation to the code"
 
 ### Analyze Patterns
 - "How do we use [service/API]?"
@@ -131,3 +152,4 @@ When the AI detects the user is working in a documentation context (files in `/d
 - "The setup guide is outdated" → `/document update setup-guide`
 - "How does this work?" → `/document expand [current-system]`
 - "Add an example" → `/document expand [current-section]` with focus on examples
+- "Does this still match the code?" → `/document review [current-section]` to compare implementation vs. docs

--- a/src/core/system.md
+++ b/src/core/system.md
@@ -119,6 +119,19 @@ docs/
 - **Change summary**: Brief note of what was updated and why
 - **Cross-reference check**: Ensure related sections are still accurate
 
+### For Documentation Reviews
+**Process:**
+1. **Gather evidence**: Inspect the implementation, tests, and configuration related to the requested scope.
+2. **Cross-check statements**: Compare observed behavior with the claims made in the relevant files under `/docs/`.
+3. **Log discrepancies**: Record mismatches, outdated details, and missing coverage along with supporting code references.
+4. **Stage fixes**: Outline the precise `/document update …` prompts (or other `/document` actions) needed to resolve each discrepancy.
+
+**Output Format:**
+- **Findings summary**: Concise list of confirmed matches and detected issues.
+- **Evidence trail**: Code paths, commits, or configuration snippets that justify each mismatch.
+- **Follow-up plan**: Explicit `/document update` prompts scoped to the affected documentation files.
+- **Edit boundaries**: Reiterate that `/document review` only authorizes changes inside `docs/`; code modifications or non-doc edits must be requested separately.
+
 ## FRESH GENERATION PROCESS
 
 ### STEP 1: COMPREHENSIVE WORKSPACE ANALYSIS

--- a/src/templates/ai-configs/claude.md
+++ b/src/templates/ai-configs/claude.md
@@ -56,6 +56,20 @@ Each command entry lists natural language cues Claude should recognize, followed
   - Describe the adjustments made, including files touched and issues resolved.
   - Point out any remaining open questions or TODOs discovered during the update.
 
+### `/document review [scope]`
+- **Natural language cues**: "Is this doc still accurate?", "Audit the payments guide", "Review the API reference against the code".
+- **Intent**: Verify that existing documentation matches the current implementation and stage targeted fixes.
+- **Expected LLM actions**:
+  1. Execute `/document review <scope>`—the entire review is orchestrated through `/document` prompts.
+  2. Gather current behavior evidence from relevant code, tests, and configuration.
+  3. Compare findings with the statements in the corresponding `/docs/` files.
+  4. Summarize mismatches and propose follow-up `/document update …` prompts (or other `/document` actions) scoped to the affected docs.
+  5. Remember: the review command only authorizes edits inside `docs/`; never suggest direct code changes in this phase.
+- **Output expectations**:
+  - Provide a structured findings report highlighting confirmed matches and discrepancies.
+  - Cite the supporting code evidence for each issue.
+  - List the exact follow-up prompts developers should run to resolve the gaps.
+
 ### `/document analyze [integration]`
 - **Natural language cues**: "How do we use Stripe?", "Document the MongoDB integration", "Explain our AWS setup".
 - **Intent**: Produce integration-focused documentation that maps external services to in-repo usage.

--- a/src/templates/ai-configs/copilot-instructions.md
+++ b/src/templates/ai-configs/copilot-instructions.md
@@ -49,6 +49,19 @@ Each entry includes the intent, the actions Copilot should perform, and the outp
   - Explain which files were updated and what changed.
   - Surface any open questions or TODOs encountered during the update.
 
+### `/document review [scope]`
+- **Intent**: Audit existing documentation against the current implementation and plan targeted fixes.
+- **Expected LLM actions**:
+  1. Execute `/document review <scope>`—reviews are driven entirely through `/document` prompts.
+  2. Gather fresh evidence from the relevant code, tests, and configuration.
+  3. Compare that evidence to the statements in the associated `/docs/` files.
+  4. Summarize confirmations and mismatches, calling out risks or outdated instructions.
+  5. Stage explicit `/document update …` prompts (or other `/document` actions) for each issue; remember that the review command only authorizes edits inside `docs/`.
+- **Output expectations**:
+  - Deliver a findings report that pairs each discrepancy with supporting evidence.
+  - Highlight any areas that remain accurate to reinforce confidence.
+  - Provide the follow-up prompt list developers should run to close the gaps.
+
 ### `/document analyze [integration]`
 - **Intent**: Document how the codebase interacts with an external service or dependency.
 - **Expected LLM actions**:
@@ -80,7 +93,7 @@ Each entry includes the intent, the actions Copilot should perform, and the outp
   - Call out gaps that might warrant new documentation.
 
 ## Natural Language Mapping
-Copilot should treat phrases such as "Document this feature", "Update the deployment guide", "How do we integrate with Stripe?", "Fix the docs navigation", and "Find docs about authentication" as triggers for the corresponding `/document` commands listed above.
+Copilot should treat phrases such as "Document this feature", "Update the deployment guide", "Audit the payments doc", "How do we integrate with Stripe?", "Fix the docs navigation", and "Find docs about authentication" as triggers for the corresponding `/document` commands listed above.
 
 ## Fallback Responsibilities
 - When `/document` automation is unavailable, Copilot remains responsible for drafting the requested content.

--- a/src/templates/ai-configs/cursor-rules.md
+++ b/src/templates/ai-configs/cursor-rules.md
@@ -42,6 +42,19 @@ Each command entry maintains the **Intent → Expected LLM actions → Output ex
   - Describe the adjustments made and reference the affected files.
   - Capture any open issues uncovered during the update.
 
+### `/document review [scope]`
+- **Intent**: Assess existing documentation accuracy and stage targeted corrections.
+- **Expected LLM actions**:
+  1. Run `/document review <scope>`—all review activity is mediated through `/document` prompts.
+  2. Collect evidence from the relevant code, tests, and configuration to describe current behavior.
+  3. Compare those observations with the claims in the matching `/docs/` content.
+  4. Summarize matches, discrepancies, and risks.
+  5. Outline the exact `/document update …` prompts (or other `/document` actions) needed to fix each issue, noting that the review command authorizes edits only within `docs/`.
+- **Output expectations**:
+  - Produce a structured findings summary with evidence links.
+  - Highlight documentation areas that remain accurate to confirm coverage.
+  - Provide the follow-up prompt checklist required to remediate gaps.
+
 ### `/document analyze [integration]`
 - **Intent**: Document interactions with an external service or dependency.
 - **Expected LLM actions**:
@@ -72,7 +85,7 @@ Each command entry maintains the **Intent → Expected LLM actions → Output ex
   - Note gaps where new documentation would add value.
 
 ## Language Mapping and Support
-- Treat phrases such as "Document this component", "Update the README", "How do we integrate Stripe?", "Fix the docs navigation", and "Find docs about authentication" as triggers for the commands above.
+- Treat phrases such as "Document this component", "Update the README", "Audit the payments doc", "How do we integrate Stripe?", "Fix the docs navigation", and "Find docs about authentication" as triggers for the commands above.
 - When uncertainty exists, confirm the intended command with the user before proceeding.
 
 ## Fallback Responsibilities

--- a/src/templates/ai-configs/gemini.md
+++ b/src/templates/ai-configs/gemini.md
@@ -42,6 +42,19 @@ Every entry follows the **Intent → Expected LLM actions → Output expectation
   - Describe what changed, including files updated and issues resolved.
   - Identify any follow-up work still needed.
 
+### `/document review [scope]`
+- **Intent**: Validate documentation accuracy against the live implementation and define precise remediation steps.
+- **Expected LLM actions**:
+  1. Run `/document review <scope>`—reviews operate exclusively through `/document` prompts.
+  2. Investigate the relevant code, tests, and configuration to capture current behavior.
+  3. Compare those findings to the claims in the matching `/docs/` material.
+  4. Summarize agreements, discrepancies, and potential risks.
+  5. Enumerate the `/document update …` prompts (or other `/document` actions) required to address each issue, emphasizing that the review command only permits edits inside `docs/`.
+- **Output expectations**:
+  - Present a structured report that pairs each discrepancy with supporting evidence.
+  - Confirm which portions of the documentation remain accurate.
+  - Supply the follow-up prompt list needed to remediate the gaps.
+
 ### `/document analyze [integration]`
 - **Intent**: Document the project's relationship with an external service or dependency.
 - **Expected LLM actions**:
@@ -72,7 +85,7 @@ Every entry follows the **Intent → Expected LLM actions → Output expectation
   - Point out missing coverage that may warrant future documentation.
 
 ## Natural Language Recognition
-Recognize phrases such as "Generate project docs", "Document the authentication flow", "Update the API guide", "How do we use Stripe?", "Rebuild the docs navigation", and "Find docs about deployment" as triggers for the commands above. Confirm intent with the user if ambiguity remains.
+Recognize phrases such as "Generate project docs", "Document the authentication flow", "Audit the payments documentation", "Update the API guide", "How do we use Stripe?", "Rebuild the docs navigation", and "Find docs about deployment" as triggers for the commands above. Confirm intent with the user if ambiguity remains.
 
 ## Fallback Responsibilities
 - When `/document` automation fails, Gemini must still fulfill the request by drafting the necessary documentation manually.


### PR DESCRIPTION
## Summary
- describe the new `/document review` command in the core command catalog and runtime instructions
- expand assistant configuration templates so every persona follows the prompt-only review workflow and stages `/document update` follow-ups
- refresh user-facing docs to advertise the review command and clarify how reviews audit docs against the codebase

## Testing
- not run (documentation-only changes)


------
https://chatgpt.com/codex/tasks/task_e_68df2da0f45c8321a9fd18628e68b356