### PR TITLE
Reinforce docs-only documentation workflow guardrails

### DIFF
--- a/docs/03-development/02-cli-deep-dive.md
+++ b/docs/03-development/02-cli-deep-dive.md
@@ -14,6 +14,11 @@ A notable feature of the CLI is its 80s vaporwave-inspired aesthetic, complete w
 
 The `run()` method is the main entry point, parsing `process.argv` to determine which command to execute.
 
+### Documentation Safety Boundaries
+
+- `/document` commands must only modify files inside the `docs/` directory. Treat the rest of the repository (including `README.md`, configuration files, and source code) as read-only during documentation sessions.
+- When you discover outdated information outside `docs/`, note the discrepancy in your response and escalate through the project's documentation issue template or maintainer channel rather than editing the file yourself.
+
 ### `init`
 
 -   **Purpose**: Initializes DocuMind in a project.

--- a/docs/_sidebar.md
+++ b/docs/_sidebar.md
@@ -26,6 +26,8 @@
 - **Update**: `/document update section "[section]"`
 - **Bootstrap**: `/document bootstrap` (regenerate all)
 
+> **Scope Reminder**: `/document` operations may only edit files within `docs/`. If non-doc files like `README.md` seem out of sync, flag the issue and request maintainer follow-up instead of modifying them.
+
 ### 🎯 Quick Actions
 
 - [📝 Request Documentation Update](https://github.com/denniswebb/documind/issues/new?template=documentation-request.md&labels=documentation)

--- a/src/core/system.md
+++ b/src/core/system.md
@@ -200,6 +200,7 @@ For each external service identified:
 ## Critical Rules
 
 ### NEVER:
+- Edit files outside the `docs/` directory during `/document` operations. If you discover discrepancies in files like `README.md` or other non-doc assets, raise an explicit alert and request maintainer review instead of modifying them yourself.
 - Modify or delete `.documind/` contents (system is immutable)
 - Overwrite existing documentation without preserving key information
 - Create duplicate sections that already exist

--- a/src/templates/ai-configs/claude.md
+++ b/src/templates/ai-configs/claude.md
@@ -2,6 +2,8 @@
 
 DocuMind manages documentation through the `/document` command family. Claude agents should follow the behaviors defined in [`src/core/commands.md`](../../core/commands.md) and the mirrored runtime reference at `.documind/core/commands.md` when installed locally.
 
+> **Documentation Scope Guardrail**: During `/document` tasks, only modify files under `docs/`. If you spot outdated information in `README.md` or any other non-doc file, do **not** edit it—raise an alert in your response so maintainers can address it separately.
+
 ## Automatic Documentation Generation Overview
 
 DocuMind's **Automatic Documentation Generation** pipeline still begins with environment detection before orchestrating `/document` commands. When operating in a local checkout:

--- a/src/templates/ai-configs/copilot-instructions.md
+++ b/src/templates/ai-configs/copilot-instructions.md
@@ -2,6 +2,8 @@
 
 Copilot should orchestrate DocuMind through the `/document` command family. Review [`src/core/commands.md`](../../core/commands.md) (and the runtime mirror `.documind/core/commands.md`) for the authoritative behaviors and parameters.
 
+> **Documentation Scope Guardrail**: Restrict all `/document` edits to the `docs/` tree. When you notice drift in `README.md` or any other non-doc file, report the discrepancy and escalate rather than modifying those files yourself.
+
 ## Automatic Documentation Generation Checks
 
 - Run `node .documind/scripts/detect-documind.js ai-report` to verify that Automatic Documentation Generation is available and to locate `.documind/scripts/ai-orchestrator.js`.

--- a/src/templates/ai-configs/copilot-prompt.md
+++ b/src/templates/ai-configs/copilot-prompt.md
@@ -2,6 +2,8 @@ Intelligent documentation command processor for DocuMind projects.
 
 This prompt assumes DocuMind's `/document` commands behave as defined in [`src/core/commands.md`](../../core/commands.md) and mirrored at `.documind/core/commands.md` when DocuMind is installed locally.
 
+> **Documentation Scope Guardrail**: Limit every `/document` edit to `docs/`. When you identify stale information in `README.md` or other non-doc files, flag it explicitly and ask for maintainer follow-up instead of editing those files.
+
 ## Core Processing Pattern
 1. Determine which `/document` intent the request maps to.
 2. Execute the command (or simulate its effects when automation is unavailable).

--- a/src/templates/ai-configs/cursor-rules.md
+++ b/src/templates/ai-configs/cursor-rules.md
@@ -2,6 +2,8 @@
 
 Cursor agents manage documentation through DocuMind's `/document` commands. Follow the behaviors defined in [`src/core/commands.md`](../../core/commands.md) and, when running locally, the synchronized reference at `.documind/core/commands.md`.
 
+> **Documentation Scope Guardrail**: Only edit files inside `docs/` during `/document` work. When you detect outdated information in `README.md` or any other non-doc file, surface the issue and request maintainer intervention instead of changing those files yourself.
+
 ## Standard Operating Sequence
 1. Detect the user's intent and map it to a `/document` command.
 2. Execute the command (or simulate its effects if automation is unavailable).

--- a/src/templates/ai-configs/gemini.md
+++ b/src/templates/ai-configs/gemini.md
@@ -2,6 +2,8 @@
 
 Gemini agents handle documentation through DocuMind's `/document` command suite. Behaviors are defined in [`src/core/commands.md`](../../core/commands.md) and mirrored for local use at `.documind/core/commands.md`.
 
+> **Documentation Scope Guardrail**: Keep all `/document` edits inside `docs/`. When you notice outdated content in `README.md` or other non-doc assets, call it out and request maintainer escalation instead of editing those files directly.
+
 ## Execution Blueprint
 1. Map the user request to a `/document` intent.
 2. Run the corresponding command (or emulate it if automation is unavailable).


### PR DESCRIPTION
## Summary
- add an explicit docs-only edit rule with escalation guidance to the system instructions
- propagate the docs-only guardrail across all AI assistant configuration templates
- update user-facing documentation to reiterate the restriction and outline the escalation path

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68df2ebd90948321b12d81b28b56089a