### PR TITLE
Add concept and development workflow documentation

### DIFF
--- a/docs/02-core-concepts/02-generator-safeguards.md
+++ b/docs/02-core-concepts/02-generator-safeguards.md
@@ -1,0 +1,27 @@
+# Generator Safeguards and Removal Rationale
+
+DocuMind intentionally removed the "always run the generator" default to keep existing documentation safe. The [system instructions](../../src/core/system.md) direct every session to check for an existing `/docs` tree and to **avoid automatic regeneration when one is present**. Instead, they emphasize incremental updates and context preservation so previously curated guidance is never overwritten without intent.
+
+## Why full regeneration is opt-in
+
+- **Step 0 gatekeeping** – The very first task in the system instructions is to verify whether documentation already exists. When it does, the assistant must surface `/document …` options instead of running a generator, preventing destructive rebuilds of curated chapters.
+- **Core principles** – The same instructions prioritize living documentation, incremental updates, and smart placement, all of which are incompatible with an unconditional generator pass. Those guardrails encode the rationale for disabling unattended generation during normal interactions.
+
+## Where the legacy generator still runs
+
+DocuMind retains the legacy generator class for deliberate workflows that need it:
+
+- The AI orchestrator’s [`bootstrapDocumentation()` routine](../../src/scripts/ai-orchestrator.js) calls `generator.generateAll()` only after installation detection succeeds. The command is available through `/document bootstrap`, making the capability explicit and auditable.
+- Follow-on flows such as [`expandConcept()`](../../src/scripts/ai-orchestrator.js) reuse `generator.generateFromManifest()` for targeted updates, ensuring generation is scoped to a requested concept instead of rebuilding everything.
+
+## Operational checklist
+
+When a contributor needs fresh outputs, treat the generator as an opt-in tool:
+
+1. Confirm the desired intent (`bootstrap`, `expand`, or `analyze`) and invoke it through the `/document` interface so the orchestrator mediates execution.
+2. Inspect the resulting manifests and token usage if you trigger full generation, since the generator enforces token budgets before writing files.
+3. Re-run the master AI index (`/document index`) if you add new files so navigation stays synchronized with generated assets.
+
+## Troubleshooting guidance
+
+If someone reports that documentation regenerated unexpectedly, verify the interaction log. A direct call to `/document bootstrap` or a manual `node .documind/scripts/ai-orchestrator.js bootstrap` run is the only supported path for full regeneration; routine `/document` operations fall back to targeted expansion flows.

--- a/docs/02-core-concepts/03-prompt-orchestration-flow.md
+++ b/docs/02-core-concepts/03-prompt-orchestration-flow.md
@@ -1,0 +1,34 @@
+# Prompt Orchestration Flow
+
+The `/document` family of prompts routes through the AI orchestration script that ships with DocuMind. Understanding how the orchestrator sequences validation, command handling, and generation makes it easier to diagnose automation issues and extend the workflow responsibly.
+
+## Entry point and environment validation
+
+1. AI agents call `ai-orchestrator.js` with a verb such as `bootstrap`, `expand`, or `search`.
+2. The orchestrator constructs helper classes (`Generator`, `AIIndexBuilder`) and records the working directory at instantiation.
+3. Before executing a command it runs `validateInstallation()`, which ensures that `.documind/core` and `.documind/templates` exist. The check prevents commands from running in partially installed workspaces.
+
+## Command dispatch
+
+- `execute()` calculates timing metadata and forwards the request to `executeCommand()`.
+- `executeCommand()` uses a switch statement to map verbs to dedicated routines: `bootstrapDocumentation`, `expandConcept`, `analyzeIntegration`, `updateSection`, `rebuildIndex`, and `searchDocumentation`.
+- Unknown commands trigger an explicit error, keeping the interaction contract narrow.
+
+## Generation verbs
+
+- **Bootstrap** – `bootstrapDocumentation()` runs `generator.generateAll()` against every manifest, mirrors the results into human and AI directories, updates the AI index, and rebuilds the Docsify skeleton.
+- **Expand / Update** – `expandConcept()` and `updateSection()` reuse `generator.generateFromManifest()` for a specific name, then refresh the AI index. `updateSection()` simply calls `expandConcept()` with `mode: 'update'` semantics, keeping the implementation DRY.
+- **Analyze** – `analyzeIntegration()` filters manifests for integration templates and executes them with the supplied service name, returning token counts alongside generated paths.
+
+## Non-generative verbs
+
+- **Index** – `rebuildIndex()` calls the AI index builder directly to rescan generated outputs.
+- **Search** – `searchDocumentation()` walks every Markdown file under `/docs` and `/docs/ai`, collecting line matches for the requested query. The helper gracefully handles missing directories.
+
+## Operational tips
+
+- The orchestrator only runs after the installation check passes, so failed commands often indicate that `.documind` was not installed or was removed during a cleanup. Re-run `documind init` if necessary.
+- Each routine returns structured metadata (counts, timestamps, affected paths), which downstream agents can surface to users for transparency or integrate into progress dashboards.
+- When building new automation, prefer adding verbs to `executeCommand()` instead of bypassing the orchestrator so validation and logging remain consistent.
+
+For a deep dive into how the orchestrator fits within DocuMind’s safety rails, pair this guide with the [generator safeguards overview](./02-generator-safeguards.md) and the canonical [system instructions](../../src/core/system.md).

--- a/docs/02-core-concepts/04-ai-config-lifecycle.md
+++ b/docs/02-core-concepts/04-ai-config-lifecycle.md
@@ -1,0 +1,29 @@
+# AI Configuration Lifecycle
+
+DocuMind provisions IDE-specific prompt playbooks during installation and protects local edits during updates. The lifecycle is orchestrated by the CLI (`install.js`) and the templates in [`src/templates/ai-configs/`](../../src/templates/ai-configs/).
+
+## Detection and generation
+
+1. `documind init` calls `generateAIConfigs()`, which first detects available tools (Claude, Copilot, Cursor, Gemini).
+2. For each detected tool, the CLI reads the matching template (for example, `ai-configs/claude.md`) from the packaged source and writes it into the project (`CLAUDE.md`, `.github/copilot-instructions.md`, `.cursorrules`, `GEMINI.md`).
+3. The routine prints progress for each tool so contributors can confirm which assistants were configured.
+
+## Update safety
+
+- `documind update` reuses the same `generateAIConfigs()` method. Before overwriting, it calls `handleExistingAIConfig()` to inspect the current file.
+- If the file already contains DocuMind guidance (`DocuMind` or `/document` markers), the method returns early to preserve user edits.
+- In non-interactive contexts (CI, GitHub Actions, or any session without a TTY) the CLI automatically appends the new DocuMind section after backing up the original file. The backup filename includes a timestamp for traceability.
+
+## Template responsibilities
+
+Each template under `src/templates/ai-configs/` provides:
+
+- **Command playbooks** tailored to the assistant, ensuring `/document` verbs map to the orchestrator and system rules.
+- **Fallback guidance** describing how to proceed when automation is unavailable.
+- **Cross-references** back to the shared [command reference](../../src/core/commands.md) and orchestrator entry points so the instructions remain grounded in runtime behavior.
+
+## Maintenance tips
+
+- When updating prompt language, edit the source templates first—DocuMind uses them for both fresh installs and appended updates.
+- After changing templates, run `documind update --debug` in a sample project to confirm backups are created and the appended section renders correctly.
+- Keep template links current (for example, paths to `ai-orchestrator.js` or command guides) so `/document review` prompts can trace statements back to code without manual sleuthing.

--- a/docs/02-core-concepts/README.md
+++ b/docs/02-core-concepts/README.md
@@ -1,8 +1,13 @@
 # Chapter 2: Core Concepts
 
-This chapter explains the key abstractions and concepts in DocuMind.
+This chapter documents the architectural guardrails that keep DocuMind's hybrid human/AI documentation system dependable.
 
-*This chapter is a work in progress. Use the `/document expand concept "[concept-name]"` command to add content.*
+## Sections
+
+- **[CLI System](./01-cli-system.md)**: Command patterns and installer responsibilities.
+- **[Generator Safeguards and Removal Rationale](./02-generator-safeguards.md)**: Why comprehensive generation is opt-in and how the legacy generator is contained.
+- **[Prompt Orchestration Flow](./03-prompt-orchestration-flow.md)**: How `/document` prompts are routed through the AI orchestrator.
+- **[AI Configuration Lifecycle](./04-ai-config-lifecycle.md)**: How installation, updates, and backups keep IDE playbooks synchronized.
 
 [Back to Home](../README.md)
 

--- a/docs/03-development/03-contributor-workflow.md
+++ b/docs/03-development/03-contributor-workflow.md
@@ -1,0 +1,31 @@
+# Contributor Workflow
+
+This workflow keeps code, documentation, and AI playbooks aligned when contributing changes to DocuMind.
+
+## 1. Create a feature branch
+
+- Use descriptive branch names (e.g., `feature/prompt-index`) so review threads map cleanly to the scope of work.
+- Install DocuMind locally (`npm install` followed by `node install.js init` in a sandbox project) if you need to verify the generated assets.
+
+## 2. Update documentation intentionally
+
+- Follow the [system instructions](../../src/core/system.md) that prioritize incremental updates. Prefer `/document expand …` and `/document update …` prompts over full regeneration so curated chapters stay intact.
+- When adding new guides, wire them into the Docsify navigation (`docs/_sidebar.md`) so the material is discoverable.
+- Cross-link statements back to their source modules (for example, `src/core/system.md` or `src/templates/ai-configs/`) to support future `/document review` audits.
+
+## 3. Run automated tests
+
+- Execute `npm test` for unit coverage and `npm run test:integration` for end-to-end flows before opening a pull request.
+- Use `npm run coverage:report` if your change affects token counting or manifest processing; it runs the coverage suite and validates thresholds via `tests/coverage-validation.js`.
+
+## 4. Prepare the pull request
+
+- Summarize code and documentation changes, including which `/document` prompts were used or which templates were edited.
+- Highlight any regenerated AI configuration files and link to the corresponding templates under `src/templates/ai-configs/`.
+- Ensure the Docsify sidebar and chapter indices include the new material so reviewers can navigate without guesswork.
+
+## 5. Keep history reviewable
+
+- Commit frequently with messages that describe the observable change (e.g., `docs: add prompt orchestration guide`).
+- Avoid committing generated `/docs/ai` assets unless the change specifically targets AI output templates; the orchestrator can regenerate them when needed.
+- Retain backups produced by `handleExistingAIConfig()` during updates until the pull request is merged—they document how local prompt files evolved.

--- a/docs/03-development/04-testing-strategy.md
+++ b/docs/03-development/04-testing-strategy.md
@@ -1,0 +1,34 @@
+# Testing Strategy
+
+DocuMind relies on the Node.js test runner (`node --test`) and a focused suite of unit and integration tests to protect the documentation pipeline.
+
+## Test layout
+
+- **Unit tests** live in `tests/unit/` and cover foundational modules such as the CLI, generator, template processor, and AI orchestration scripts.
+- **Integration tests** in `tests/integration/` exercise higher-level behaviors, ensuring commands work end-to-end against fixture workspaces.
+- Additional directories (`tests/performance/`, if present) can plug into the same runner via dedicated npm scripts.
+
+## npm scripts
+
+The `package.json` scripts expose common combinations:
+
+| Script | Purpose |
+| --- | --- |
+| `npm test` | Runs all unit tests (`node --test tests/unit/*.test.js`). |
+| `npm run test:integration` | Executes integration specs (`node --test tests/integration/*.test.js`). |
+| `npm run test:all` | Runs unit tests, then integration tests in sequence. |
+| `npm run test:coverage` | Enables coverage instrumentation for every test file. |
+| `npm run coverage:report` | Generates coverage, validates thresholds, and invokes `tests/coverage-validation.js`. |
+| `npm run test:watch` | Watches unit tests for rapid feedback during development. |
+
+For cross-version assurance, the `test:matrix` script chains Node 16/18/20/21 executions by reusing `test:all` with a `NODE_VERSION` environment variable.
+
+## Coverage validation
+
+`tests/coverage-validation.js` enforces minimum coverage (90% lines/functions/statements, 80% branches) and regenerates reports if they are missing. The validator also verifies dual-purpose generation flows by invoking the coverage suite before evaluating thresholds.
+
+## Local tips
+
+- Run `npm run test:coverage:html` to produce a browsable report in `coverage/` when auditing token-heavy changes.
+- If tests intermittently fail, re-run `npm run test:integration` with `DOCUMIND_TEST_CWD` pointed at a clean temp directory to isolate filesystem side effects.
+- Prefer adding new tests alongside the module they exercise to keep the unit/integration split intuitive for reviewers.

--- a/docs/03-development/05-prompt-playbook-maintenance.md
+++ b/docs/03-development/05-prompt-playbook-maintenance.md
@@ -1,0 +1,25 @@
+# Prompt Playbook Maintenance
+
+DocuMind distributes AI assistant instructions from the templates in `src/templates/ai-configs/` and keeps local copies in sync through the installer.
+
+## Where playbooks live
+
+- Source templates: `src/templates/ai-configs/*.md` contain the canonical instructions for Claude, Copilot, Cursor, and Gemini.
+- Installed outputs: `documind init` writes the rendered files to the repository root (`CLAUDE.md`, `GEMINI.md`), `.github/` (`copilot-instructions.md`), and `.cursor/` (`.cursorrules`).
+- Command mirroring: Templates reference `src/core/system.md` and `src/core/commands.md` so IDE prompts stay aligned with the runtime behavior of `/document` commands.
+
+## Updating templates
+
+1. Modify the template under `src/templates/ai-configs/`.
+2. Run `node install.js update --debug` inside a fixture project to regenerate the local copies.
+3. Review the appended section (or backup file) created by `handleExistingAIConfig()` to ensure the new guidance merged cleanly.
+
+## Reviewing local copies
+
+- Each update creates a `*.backup-<timestamp>` file before appending DocuMind content. Keep these backups until the change merges—they provide reviewers with a diff-friendly history of prompt adjustments.
+- For assistants that support command-specific prompts (e.g., Claude’s `.claude/commands/document.md`), confirm the auxiliary files updated by the installer reflect your edits.
+- If an AI tool is removed from the template detection list, also delete or deprecate its installed counterpart to avoid stale instructions.
+
+## Cross-linking expectations
+
+When editing templates, add or refresh links that point back to the orchestrator (`src/scripts/ai-orchestrator.js`) and the system guide. Doing so allows `/document review` prompts to verify every instruction against the source module that implements it.

--- a/docs/03-development/README.md
+++ b/docs/03-development/README.md
@@ -4,7 +4,11 @@ This chapter provides guides and references for developers working on DocuMind.
 
 ## Sections
 
-- **[Setup](./01-setup.md)**: How to set up your development environment.
+- **[Setup](./01-setup.md)**: How to configure a local development environment.
+- **[CLI Deep Dive](./02-cli-deep-dive.md)**: Architecture of the installer and command dispatcher.
+- **[Contributor Workflow](./03-contributor-workflow.md)**: Branching, documentation sync, and review expectations for pull requests.
+- **[Testing Strategy](./04-testing-strategy.md)**: How automated tests are organized and which npm scripts exercise them.
+- **[Prompt Playbook Maintenance](./05-prompt-playbook-maintenance.md)**: Keeping AI assistant instructions aligned with source templates.
 
 [Back to Home](../README.md)
 

--- a/docs/_sidebar.md
+++ b/docs/_sidebar.md
@@ -11,11 +11,17 @@
 - **⚙️ Chapter 2: Core Concepts**
   - [Overview](02-core-concepts/README.md)
   - [CLI System](02-core-concepts/01-cli-system.md)
+  - [Generator Safeguards](02-core-concepts/02-generator-safeguards.md)
+  - [Prompt Orchestration Flow](02-core-concepts/03-prompt-orchestration-flow.md)
+  - [AI Configuration Lifecycle](02-core-concepts/04-ai-config-lifecycle.md)
 
 - **🛠️ Chapter 3: Development**
   - [Overview](03-development/README.md)
   - [Setup](03-development/01-setup.md)
   - [CLI Deep Dive](03-development/02-cli-deep-dive.md)
+  - [Contributor Workflow](03-development/03-contributor-workflow.md)
+  - [Testing Strategy](03-development/04-testing-strategy.md)
+  - [Prompt Playbook Maintenance](03-development/05-prompt-playbook-maintenance.md)
 
 ---
 


### PR DESCRIPTION
## Summary
- replace the core concepts overview with links to new guides covering generator safeguards, prompt orchestration, and AI configuration lifecycle
- add development chapter guides for contributor workflow, testing strategy, and prompt playbook maintenance, and wire them into the Docsify sidebar
- cross-link the new content to the system instructions, orchestrator script, and AI config templates to support future `/document review` workflows

## Testing
- not run (documentation only)


------
https://chatgpt.com/codex/tasks/task_e_68df308e90c883219fe78c9f941dac67